### PR TITLE
Remove custom names from `displaynames.xml`

### DIFF
--- a/src/Resources/displaynames.xml
+++ b/src/Resources/displaynames.xml
@@ -96,11 +96,6 @@
 		<Ordinal>1</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>297</ID>
-		<Name>Anya</Name>
-		<Ordinal>1</Ordinal>
-	</DisplayName>
-	<DisplayName>
 		<ID>20</ID>
 		<Name>April</Name>
 		<Ordinal>1</Ordinal>
@@ -271,21 +266,6 @@
 		<Ordinal>1</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>304</ID>
-		<Name>Doc</Name>
-		<Ordinal>1</Ordinal>
-	</DisplayName>
-	<DisplayName>
-		<ID>303</ID>
-		<Name>Doctor</Name>
-		<Ordinal>1</Ordinal>
-	</DisplayName>
-	<DisplayName>
-		<ID>305</ID>
-		<Name>Document</Name>
-		<Ordinal>1</Ordinal>
-	</DisplayName>
-	<DisplayName>
 		<ID>54</ID>
 		<Name>Dylan</Name>
 		<Ordinal>1</Ordinal>
@@ -348,11 +328,6 @@
 	<DisplayName>
 		<ID>66</ID>
 		<Name>Grace</Name>
-		<Ordinal>1</Ordinal>
-	</DisplayName>
-	<DisplayName>
-		<ID>299</ID>
-		<Name>Gummy</Name>
 		<Ordinal>1</Ordinal>
 	</DisplayName>
 	<DisplayName>
@@ -423,11 +398,6 @@
 	<DisplayName>
 		<ID>80</ID>
 		<Name>Jeffrey</Name>
-		<Ordinal>1</Ordinal>
-	</DisplayName>
-	<DisplayName>
-		<ID>302</ID>
-		<Name>Jemmy</Name>
 		<Ordinal>1</Ordinal>
 	</DisplayName>
 	<DisplayName>
@@ -513,11 +483,6 @@
 	<DisplayName>
 		<ID>97</ID>
 		<Name>Kim</Name>
-		<Ordinal>1</Ordinal>
-	</DisplayName>
-	<DisplayName>
-		<ID>300</ID>
-		<Name>Kitty</Name>
 		<Ordinal>1</Ordinal>
 	</DisplayName>
 	<DisplayName>
@@ -608,11 +573,6 @@
 	<DisplayName>
 		<ID>115</ID>
 		<Name>Megumi</Name>
-		<Ordinal>1</Ordinal>
-	</DisplayName>
-	<DisplayName>
-		<ID>298</ID>
-		<Name>Melee</Name>
 		<Ordinal>1</Ordinal>
 	</DisplayName>
 	<DisplayName>
@@ -831,16 +791,6 @@
 		<Ordinal>1</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>301</ID>
-		<Name>Violet</Name>
-		<Ordinal>1</Ordinal>
-	</DisplayName>
-	<DisplayName>
-		<ID>296</ID>
-		<Name>Vivian</Name>
-		<Ordinal>1</Ordinal>
-	</DisplayName>
-	<DisplayName>
 		<ID>159</ID>
 		<Name>William</Name>
 		<Ordinal>1</Ordinal>
@@ -858,11 +808,6 @@
 	<DisplayName>
 		<ID>162</ID>
 		<Name>Zoe</Name>
-		<Ordinal>1</Ordinal>
-	</DisplayName>
-	<DisplayName>
-		<ID>295</ID>
-		<Name>Zundamon</Name>
 		<Ordinal>1</Ordinal>
 	</DisplayName>
 	<DisplayName>
@@ -1022,506 +967,496 @@
 	</DisplayName>
 	<DisplayName>
 		<ID>194</ID>
-		<Name>Moon</Name>
-		<Ordinal>2</Ordinal>
-	</DisplayName>
-	<DisplayName>
-		<ID>195</ID>
 		<Name>Orange</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>196</ID>
+		<ID>195</ID>
 		<Name>Pink</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>197</ID>
+		<ID>196</ID>
 		<Name>Pixie</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>198</ID>
+		<ID>197</ID>
 		<Name>Pretty</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>199</ID>
+		<ID>198</ID>
 		<Name>Purple</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>200</ID>
+		<ID>199</ID>
 		<Name>Rain</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>201</ID>
+		<ID>200</ID>
 		<Name>Rainbow</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>202</ID>
+		<ID>201</ID>
 		<Name>Red</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>203</ID>
+		<ID>202</ID>
 		<Name>Ruby</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>204</ID>
+		<ID>203</ID>
 		<Name>Shiny</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>205</ID>
+		<ID>204</ID>
 		<Name>Silly</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>206</ID>
+		<ID>205</ID>
 		<Name>Silver</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>207</ID>
+		<ID>206</ID>
 		<Name>Sky</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>208</ID>
+		<ID>207</ID>
 		<Name>Sloth</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>209</ID>
+		<ID>208</ID>
 		<Name>Sparkle</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>210</ID>
+		<ID>209</ID>
 		<Name>Speedy</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>211</ID>
+		<ID>210</ID>
 		<Name>Star</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>212</ID>
+		<ID>211</ID>
 		<Name>Strong</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>213</ID>
+		<ID>212</ID>
 		<Name>Sweet</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>214</ID>
+		<ID>213</ID>
 		<Name>Swift</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>215</ID>
+		<ID>214</ID>
 		<Name>Thunder</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>216</ID>
+		<ID>215</ID>
 		<Name>Tornado</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>217</ID>
+		<ID>216</ID>
 		<Name>Tough</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>218</ID>
+		<ID>217</ID>
 		<Name>Twinkle</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>219</ID>
+		<ID>218</ID>
 		<Name>Twisty</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>220</ID>
+		<ID>219</ID>
 		<Name>Volcano</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>221</ID>
+		<ID>220</ID>
 		<Name>Water</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>222</ID>
+		<ID>221</ID>
 		<Name>White</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>223</ID>
+		<ID>222</ID>
 		<Name>Wind</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>224</ID>
+		<ID>223</ID>
 		<Name>Wonder</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>225</ID>
+		<ID>224</ID>
 		<Name>Yellow</Name>
 		<Ordinal>2</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>226</ID>
-		<Name>Base</Name>
-		<Ordinal>3</Ordinal>
-	</DisplayName>
-	<DisplayName>
-		<ID>227</ID>
+		<ID>225</ID>
 		<Name>Bear</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>228</ID>
+		<ID>226</ID>
 		<Name>Bolt</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>229</ID>
+		<ID>227</ID>
 		<Name>Button</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>230</ID>
+		<ID>228</ID>
 		<Name>Camel</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>231</ID>
+		<ID>229</ID>
 		<Name>Cheetah</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>232</ID>
+		<ID>230</ID>
 		<Name>Cloud</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>233</ID>
+		<ID>231</ID>
 		<Name>Colt</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>234</ID>
+		<ID>232</ID>
 		<Name>Comet</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>235</ID>
+		<ID>233</ID>
 		<Name>Coyote</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>236</ID>
+		<ID>234</ID>
 		<Name>Daisy</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>237</ID>
+		<ID>235</ID>
 		<Name>Diamond</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>238</ID>
+		<ID>236</ID>
 		<Name>Dolphin</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>239</ID>
+		<ID>237</ID>
 		<Name>Dragon</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>240</ID>
+		<ID>238</ID>
 		<Name>Dreamer</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>241</ID>
+		<ID>239</ID>
 		<Name>Duck</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>242</ID>
+		<ID>240</ID>
 		<Name>Eagle</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>243</ID>
+		<ID>241</ID>
 		<Name>Ember</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>244</ID>
+		<ID>242</ID>
 		<Name>Emerald</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>245</ID>
+		<ID>243</ID>
 		<Name>Eye</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>246</ID>
+		<ID>244</ID>
 		<Name>Falcon</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>247</ID>
+		<ID>245</ID>
 		<Name>Feather</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>248</ID>
+		<ID>246</ID>
 		<Name>Feet</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>249</ID>
+		<ID>247</ID>
 		<Name>Foot</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>250</ID>
+		<ID>248</ID>
 		<Name>Fox</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>251</ID>
+		<ID>249</ID>
 		<Name>Gator</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>252</ID>
+		<ID>250</ID>
 		<Name>Gecko</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>253</ID>
+		<ID>251</ID>
 		<Name>Gem</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>254</ID>
+		<ID>252</ID>
 		<Name>Glacier</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>255</ID>
+		<ID>253</ID>
 		<Name>Goat</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>256</ID>
+		<ID>254</ID>
 		<Name>Hawk</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>257</ID>
+		<ID>255</ID>
 		<Name>Head</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>258</ID>
+		<ID>256</ID>
 		<Name>Heart</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>259</ID>
+		<ID>257</ID>
 		<Name>Jewel</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>260</ID>
+		<ID>258</ID>
 		<Name>Kitty</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>261</ID>
+		<ID>259</ID>
 		<Name>Legs</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>262</ID>
+		<ID>260</ID>
 		<Name>Liger</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>263</ID>
+		<ID>261</ID>
 		<Name>Lizard</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>264</ID>
+		<ID>262</ID>
 		<Name>Mask</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>265</ID>
+		<ID>263</ID>
 		<Name>Meadow</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>266</ID>
+		<ID>264</ID>
 		<Name>Mist</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>267</ID>
+		<ID>265</ID>
 		<Name>Monkey</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>268</ID>
+		<ID>266</ID>
 		<Name>Newt</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>269</ID>
+		<ID>267</ID>
 		<Name>Noodle</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>270</ID>
+		<ID>268</ID>
 		<Name>Oak</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>271</ID>
+		<ID>269</ID>
 		<Name>Panda</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>272</ID>
+		<ID>270</ID>
 		<Name>Parrot</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>273</ID>
+		<ID>271</ID>
 		<Name>Puffin</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>274</ID>
+		<ID>272</ID>
 		<Name>Puppy</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>275</ID>
+		<ID>273</ID>
 		<Name>Quartz</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>276</ID>
+		<ID>274</ID>
 		<Name>Raven</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>277</ID>
+		<ID>275</ID>
 		<Name>Rhino</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>278</ID>
+		<ID>276</ID>
 		<Name>River</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>279</ID>
+		<ID>277</ID>
 		<Name>Shark</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>280</ID>
+		<ID>278</ID>
 		<Name>Slug</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>281</ID>
+		<ID>279</ID>
 		<Name>Snake</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>282</ID>
+		<ID>280</ID>
 		<Name>Spider</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>283</ID>
+		<ID>281</ID>
 		<Name>Sprout</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>284</ID>
+		<ID>282</ID>
 		<Name>Stone</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>285</ID>
+		<ID>283</ID>
 		<Name>Swan</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>286</ID>
+		<ID>284</ID>
 		<Name>Tail</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>287</ID>
+		<ID>285</ID>
 		<Name>Toe</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>288</ID>
+		<ID>286</ID>
 		<Name>Tree</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>289</ID>
+		<ID>287</ID>
 		<Name>Turtle</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>290</ID>
+		<ID>288</ID>
 		<Name>Wasp</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>291</ID>
+		<ID>289</ID>
 		<Name>Wing</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>292</ID>
+		<ID>290</ID>
 		<Name>Wolf</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>293</ID>
+		<ID>291</ID>
 		<Name>Worm</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>
 	<DisplayName>
-		<ID>294</ID>
+		<ID>292</ID>
 		<Name>Zebra</Name>
 		<Ordinal>3</Ordinal>
 	</DisplayName>


### PR DESCRIPTION
The World of JumpStart name list (which is also currently used by Math Blaster as its own name list is not yet implemented) contains a number of names that were not available in the original game. Custom names should be added locally on individual private servers rather than being in the official repository. Thanks to YesntSoup for the new XML and for testing it to ensure it works.