### PR TITLE
Change AddAchievementPoints to account for overflow and underflow

### DIFF
--- a/src/Services/AchievementService.cs
+++ b/src/Services/AchievementService.cs
@@ -82,7 +82,7 @@ namespace sodoff.Services {
                     viking.AchievementPoints.Add(xpPoints);
                 }
                 
-				int initialPoints = xpPoints.Value;
+		int initialPoints = xpPoints.Value;
                 xpPoints.Value += value ?? 0;
                 
                 if (value > 0 && initialPoints > xpPoints.Value) {

--- a/src/Services/AchievementService.cs
+++ b/src/Services/AchievementService.cs
@@ -81,10 +81,16 @@ namespace sodoff.Services {
                     };
                     viking.AchievementPoints.Add(xpPoints);
                 }
+                
+				int initialPoints = xpPoints.Value;
                 xpPoints.Value += value ?? 0;
-
-                if (xpPoints.Value < 0) {
+                
+                if (value > 0 && initialPoints > xpPoints.Value) {
                     xpPoints.Value = int.MaxValue;
+                    value = int.MaxValue - initialPoints;
+                }
+                if (xpPoints.Value < 0) {
+                    xpPoints.Value = 0;
                     value = 0;
                 }
 


### PR DESCRIPTION
This is for minisaurs in WoJ, but I think it could be a good idea in general, so I didn't limit it to WoJ.

The issue happens because if you buy medicine for minisaurs. It takes away one coin, and so if you already have 0 coins, the server currently returns your coin count as int.MaxValue.

This is tested in WoJ 1.1.0 and 1.21.0. I tested buying, overflowing, underflowing, using commands with big and negative values and playing games and it worked.