### PR TITLE
Prevent logging into accounts from different games

### DIFF
--- a/src/Model/Viking.cs
+++ b/src/Model/Viking.cs
@@ -43,4 +43,5 @@ public class Viking {
     public DateTime? CreationDate { get; set; }
     public DateTime? BirthDate { get; set; }
     public Gender? Gender { get; set; }
+    public uint? GameVersion { get; set; }
 }


### PR DESCRIPTION
Unless it's between SoD versions, versions of WoJS with the same avatars, or Lands. This way, users don't accidentally mess up their player data for other games.

Tested with SoD 3.31.0, MaM, WoJS 1.1.0 and 1.21.0, MB, and SS.

[Originally authored by AlanMoonbase](https://github.com/rpaciorek/sodoff/commit/1e9ca7e19c11b246cabd46fc20585dc8a997fbc8#diff-bb10d4643a2fa54d983a574662f579e09c056f29837397a10cd9300a98fbcc7c) (I think). According to YoshiCraft64: "I chatted with moon about a week ago about random stuff and he said we're allowed to do whatever with his code"